### PR TITLE
Update Dockerfile.rocm

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -429,7 +429,7 @@ RUN microdnf install -y git nano gcc vim \
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
-    uv pip install pytest llnl-hatchet debugpy
+    uv pip install pytest llnl-hatchet debugpy llguidance
 
 # install lm_eval
 RUN --mount=type=cache,target=/root/.cache/pip \


### PR DESCRIPTION
This PR makes a minor change to the Docker file for ROCm. The llguidance package is added to avoid error messages when running lm_eval or vllm serve on MI-300X.